### PR TITLE
CD 작업을 구성한다.

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -20,7 +20,6 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
-        working-directory: ./back
 
       - name: Build and Package
         run: |

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,0 +1,48 @@
+name : build and deploy
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+        working-directory: ./back
+
+      - name: Build and Package
+        run: |
+          ./gradlew build
+          zip -qq -r ./$GITHUB_SHA.zip .
+        env:
+          FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+
+      - name: Upload to S3
+        run: aws s3 cp --region ${{ secrets.AWS_REGION }} ./back/$GITHUB_SHA.zip s3://${{ secrets.S3_BUILD_BUCKET_NAME }}/$GITHUB_SHA.zip
+
+
+      - name: Code Deploy
+        run: aws deploy create-deployment --application-name ${{ secrets.DEPLOY_APP_NAME }}
+          --deployment-config-name CodeDeployDefault.OneAtATime
+          --deployment-group-name ${{ secrets.DEPLOY_GROUP }}
+          --s3-location bucket=${{ secrets.S3_BUILD_BUCKET_NAME }},bundleType=zip,key=$GITHUB_SHA.zip

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -37,7 +37,7 @@ jobs:
 
 
       - name: Upload to S3
-        run: aws s3 cp --region ${{ secrets.AWS_REGION }} ./back/$GITHUB_SHA.zip s3://${{ secrets.S3_BUILD_BUCKET_NAME }}/$GITHUB_SHA.zip
+        run: aws s3 cp --region ${{ secrets.AWS_REGION }} ./$GITHUB_SHA.zip s3://${{ secrets.S3_BUILD_BUCKET_NAME }}/$GITHUB_SHA.zip
 
 
       - name: Code Deploy

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,18 @@
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /home/ec2-user/party-run/zip
+    overwrite: yes
+
+permissions:
+  - object: /
+    pattern: "**"
+    owner: ec2-user
+    group: ec2-user
+
+hooks:
+  AfterInstall:
+    - location: deploy.sh
+      timeout: 60
+      runas: ec2-user

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.google.firebase:firebase-admin:9.1.1'
     implementation 'com.github.SWM-KAWAI-MANS:jwt-manager:1.0.0'
-    implementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring30x:4.7.0'
 
     //lombok
     compileOnly 'org.projectlombok:lombok'
@@ -77,6 +76,7 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok-mapstruct-binding:0.2.0"
 
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring30x:4.7.0'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation ('it.ozimov:embedded-redis:0.7.3') {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ group = 'online.partyrun'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
+jar {
+    enabled = false
+}
+
 repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
@@ -61,6 +65,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.google.firebase:firebase-admin:9.1.1'
     implementation 'com.github.SWM-KAWAI-MANS:jwt-manager:1.0.0'
+    implementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring30x:4.7.0'
 
     //lombok
     compileOnly 'org.projectlombok:lombok'
@@ -74,7 +79,6 @@ dependencies {
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring30x:4.7.0'
     testImplementation ('it.ozimov:embedded-redis:0.7.3') {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
     }

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,8 +23,8 @@ else
   sleep 5
 fi
 
-OLD_JAR_NAME=$(ls -tr $REPOSITORY_DEPLOYMENT_GROUP_NAME/zip/build/libs/*.jar | tail -n 1)
-JAR_NAME=$REPOSITORY_DEPLOYMENT_GROUP_NAME/zip/build/libs/party-run-authentication-service-dev.jar
+OLD_JAR_NAME=$(ls -tr $REPOSITORY_DEPLOYMENT_GROUP_NAME/build/libs/*.jar | tail -n 1)
+JAR_NAME=$REPOSITORY_DEPLOYMENT_GROUP_NAME/build/libs/party-run-authentication-service-dev.jar
 
 mv $OLD_JAR_NAME $JAR_NAME
 echo "> JAR Name 변경: $OLD_JAR_NAME >> $JAR_NAME"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+REPOSITORY=/home/ec2-user/party-run/zip
+REPOSITORY_DEPLOYMENT_GROUP_NAME=$REPOSITORY/$DEPLOYMENT_GROUP_NAME
+
+echo "> 환경변수 불러오기"
+source ~/.bashrc
+
+echo "> 기존의 $REPOSITORY_DEPLOYMENT_GROUP_NAME/zip 폴더 삭제"
+rm -r $REPOSITORY_DEPLOYMENT_GROUP_NAME/zip
+
+echo "> 설치된 프로젝트 폴더 이동"
+mv $REPOSITORY $REPOSITORY_DEPLOYMENT_GROUP_NAME/zip
+
+echo "> 현재 구동 중인 $DEPLOYMENT_GROUP_NAME 애플리케이션 pid 확인"
+CURRENT_PID=$(pgrep -fl party-run-authentication-service-dev.jar | awk '{print $1}')
+
+if [ -z "$CURRENT_PID" ]; then
+  echo "> 현재 구동 중인 애플리케이션이 없으므로 종료하지 않습니다."
+else
+  echo "> kill -15 $CURRENT_PID"
+  sudo kill -15 $CURRENT_PID
+  sleep 5
+fi
+
+OLD_JAR_NAME=$(ls -tr $REPOSITORY_DEPLOYMENT_GROUP_NAME/zip/build/libs/*.jar | tail -n 1)
+JAR_NAME=$REPOSITORY_DEPLOYMENT_GROUP_NAME/zip/build/libs/party-run-authentication-service-dev.jar
+
+mv $OLD_JAR_NAME $JAR_NAME
+echo "> JAR Name 변경: $OLD_JAR_NAME >> $JAR_NAME"
+
+echo "> $JAR_NAME 에 실행권한 추가"
+chmod +x $JAR_NAME
+
+echo "> $JAR_NAME 실행 -Dspring.profiles.active=dev $JAR_NAME 추가해야함"
+nohup java -jar $JAR_NAME > $REPOSITORY_DEPLOYMENT_GROUP_NAME/nohup.out 2>&1 &

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,18 +1,18 @@
 #! /bin/bash
 
 REPOSITORY=/home/ec2-user/party-run/zip
-REPOSITORY_DEPLOYMENT_GROUP_NAME=$REPOSITORY/$DEPLOYMENT_GROUP_NAME
+REPOSITORY_DEPLOYMENT_GROUP_NAME=/home/ec2-user/party-run/$DEPLOYMENT_GROUP_NAME
 
 echo "> 환경변수 불러오기"
 source ~/.bashrc
 
 echo "> 기존의 $REPOSITORY_DEPLOYMENT_GROUP_NAME/zip 폴더 삭제"
-rm -r $REPOSITORY_DEPLOYMENT_GROUP_NAME/zip
+rm -r $REPOSITORY_DEPLOYMENT_GROUP_NAME
 
 echo "> 설치된 프로젝트 폴더 이동"
-mv $REPOSITORY $REPOSITORY_DEPLOYMENT_GROUP_NAME/zip
+mv $REPOSITORY $REPOSITORY_DEPLOYMENT_GROUP_NAME
 
-echo "> 현재 구동 중인 $DEPLOYMENT_GROUP_NAME 애플리케이션 pid 확인"
+echo "> 현재 구동 중인 party-run-authentication-service-dev 애플리케이션 pid 확인"
 CURRENT_PID=$(pgrep -fl party-run-authentication-service-dev.jar | awk '{print $1}')
 
 if [ -z "$CURRENT_PID" ]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,7 +6,7 @@ REPOSITORY_DEPLOYMENT_GROUP_NAME=/home/ec2-user/party-run/$DEPLOYMENT_GROUP_NAME
 echo "> 환경변수 불러오기"
 source ~/.bashrc
 
-echo "> 기존의 $REPOSITORY_DEPLOYMENT_GROUP_NAME/zip 폴더 삭제"
+echo "> 기존의 $REPOSITORY_DEPLOYMENT_GROUP_NAME 폴더 삭제"
 rm -r $REPOSITORY_DEPLOYMENT_GROUP_NAME
 
 echo "> 설치된 프로젝트 폴더 이동"

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,5 +32,5 @@ echo "> JAR Name 변경: $OLD_JAR_NAME >> $JAR_NAME"
 echo "> $JAR_NAME 에 실행권한 추가"
 chmod +x $JAR_NAME
 
-echo "> $JAR_NAME 실행 -Dspring.profiles.active=dev $JAR_NAME 추가해야함"
-nohup java -jar $JAR_NAME > $REPOSITORY_DEPLOYMENT_GROUP_NAME/nohup.out 2>&1 &
+echo "> $JAR_NAME 실행"
+nohup java -jar -Dspring.profiles.active=dev $JAR_NAME > $REPOSITORY_DEPLOYMENT_GROUP_NAME/nohup.out 2>&1 &

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    active: test
+
   data:
     redis:
       host: localhost
@@ -18,7 +21,9 @@ jwt:
   access-expire-second: 1000000
   refresh-secret-key: "assfasdfasdfadfasdfasdfasdfaasfasdfasdfadfasdfasdfasdfaasfasdfasdfadfasdfasdfasdfaasfasdfasdfadfasdfasdfasdfaasfasdfasdfadfasdfasads"
   refresh-expire-second: 2000000
+
 ---
+
 spring:
   config:
     activate:
@@ -28,8 +33,7 @@ spring:
     mongodb:
       uri: ${DB_URI}
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+      url: ${REDIS_URL}
 
 jwt:
   access-secret-key: ${JWT_ACCESS_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,18 +26,10 @@ spring:
 
   data:
     mongodb:
-      host: ${DB_HOST}
-      port: ${DB_PORT}
-      database: ${DB_DATABASE}
-      username: ${DB_USERNAME}
-      password: ${DB_PASSWORD}
-      authentication-database: ${DB_AUTH_SOURCE}
-
+      uri: ${DB_URI}
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
-      password: ${REDIS_PASSWORD}
-      database: ${REDIS_DATABASE}
 
 jwt:
   access-secret-key: ${JWT_ACCESS_SECRET_KEY}


### PR DESCRIPTION
## 변경 사항
github actions + S3 + codeDeploy로 CD 파이프라인을 구성하였습니다.
자세한 내용은 [개발 일지](https://www.notion.so/seongwoo-memo/github-actions-S3-codeDeploy-CD-b502536f50bc4489bdf63480853a3b62?pvs=4) 에 작성하였습니다.

1. cd-dev.yml
이 cd 작업은 dev환경에서만 사용할 것이기 때문에 develop 브랜치로 push가 진행될 때만 트리거가 되도록 구성하였습니다.

2. appspec.yml
code deploy가 파일 내부의 deploy.sh를 실행할 수 있도록 구성하였습니다.

4. deploy.sh
/home/ec2-user/party-run/authentication-service에 파일이 전달되도록 설정하였습니다.
다른 서비스가 추가되면 /home/ec2-user/party-run/{다른 서비스} 로 파일이 전달되어 디렉토리로 분리하기위해서 입니다.

6. application.yml
기본으로 실행되는 profile을 test로 변경하였습니다. 설정하지 않으면 embedded redis와 mongo가 실행되기 때문입니다.
로컬에서 애플리케이션을 실행한다면, local profile로 설정해야합니다.

## 알아야할 사항
서버 내부에서 환경 변수는 ~/.bashrc에서 관리합니다. deploy.sh 파일을 실행할 때 `source ~/.bashrc` 를 통해 환경 변수를 불러오도록 구성하였습니다.


## 테스트 방식
Postman으로 생성한 EC2서버에 요청을 날려야합니다.
추후에 AWS 계정을 받으면 새로운 EC2 서버로 옮겨서 다시 테스트를 진행해야합니다.
