### PR TITLE
Github actions + docker를 활용하여 ci/cd 파이프라인을 생성한다.

### DIFF
--- a/.github/workflows/build-docker-image-dev.yml
+++ b/.github/workflows/build-docker-image-dev.yml
@@ -1,0 +1,37 @@
+name: Build Backend Image Dev
+
+on:
+  workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_PASSWORD:
+        required: true
+      DOCKER_AUTHENTICATION_IMAGE_NAME:
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with jib
+        run: ./gradlew jib --image="${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_AUTHENTICATION_IMAGE_NAME }}"

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,4 +1,4 @@
-name : build and deploy
+name : cd -dev
 
 on:
   push:
@@ -6,42 +6,27 @@ on:
       - develop
 
 jobs:
-  build:
+  build-back-docker-img:
+    uses: ./.github/workflows/build-docker-image-dev.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      DOCKER_AUTHENTICATION_IMAGE_NAME: ${{ secrets.DOCKER_AUTHENTICATION_IMAGE_NAME }}
+
+  deploy:
+    needs: build-back-docker-img
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
-
-      - name: Build and Package
-        run: |
-          ./gradlew build
-          zip -qq -r ./$GITHUB_SHA.zip .
-        env:
-          FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET }}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-
-      - name: Upload to S3
-        run: aws s3 cp --region ${{ secrets.AWS_REGION }} ./$GITHUB_SHA.zip s3://${{ secrets.S3_BUILD_BUCKET_NAME }}/$GITHUB_SHA.zip
-
-
-      - name: Code Deploy
-        run: aws deploy create-deployment --application-name ${{ secrets.DEPLOY_APP_NAME }}
-          --deployment-config-name CodeDeployDefault.OneAtATime
-          --deployment-group-name ${{ secrets.DEPLOY_GROUP }}
-          --s3-location bucket=${{ secrets.S3_BUILD_BUCKET_NAME }},bundleType=zip,key=$GITHUB_SHA.zip
+    - name: executing remote ssh commands using password
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.DEV_HOST }}
+        username: ${{ secrets.DEV_HOST_USER_NAME }}
+        key: ${{ secrets.DEV_PRIVATE_KEY }}
+        script: |
+          cd ${{ secrets.DEV_DEPLOY_DIRECTORY }}
+          docker compose stop ${{ secrets.DOCKER_AUTHENTICATION_CONTAINER_NAME }}
+          docker compose rm -f ${{ secrets.DOCKER_AUTHENTICATION_CONTAINER_NAME }}
+          docker image rm ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_AUTHENTICATION_IMAGE_NAME }}
+          docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_AUTHENTICATION_IMAGE_NAME }}
+          docker compose up -d

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.1.0'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'com.google.cloud.tools.jib' version '3.2.1'
 }
 
 group = 'online.partyrun'
@@ -12,6 +13,19 @@ sourceCompatibility = '17'
 jar {
     enabled = false
 }
+
+jib {
+    from {
+        image = "openjdk:17"
+    }
+    to {
+        tags = ["latest"]
+    }
+    container {
+        jvmFlags = ["-Xms128m", "-Xmx128m"]
+    }
+}
+
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## 변경된 부분

github actions의 workflow를 생성하고, 수정하였습니다.

### 1. build.gradle에 jib 설정
jib 설정에서 image 이름을 지정하지 않습니다. 이렇게 하면 로컬에서 실수로 jib 블럭을 실행했어도 도커 허브로 push 되지 않습니다.
대신 build-docker-image-dev.yml에서 image 이름을 지정합니다.

### 2. build-docker-image-deb.yml
이 파일은 docker image를 만들어 줍니다. cd-dev.yml에서 deploy 전에 이 workflow를 실행합니다.

### 3. cd-dev.yml
빌드된 파일을 실행하기 위해 서버로 ssh로 명령어를 전달합니다.

1. 기존 컨테이너 stop
2. 기존 컨테이너 삭제
3. 기존 이미지 삭제
4. 새로운 이미지 pull
5. docker compose 실행