### PR TITLE
멤버 저장 시, 이름의 길이를 6자로 제한한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -25,11 +25,9 @@ public class Member {
     @Column(columnDefinition = "BINARY(16)")
     private UUID id;
 
-    @Unique
-    String authId;
+    @Unique String authId;
 
-    @Embedded
-    Name name;
+    @Embedded Name name;
 
     Set<Role> roles = Set.of(Role.ROLE_USER);
 

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -25,16 +25,24 @@ public class Member {
     @Column(columnDefinition = "BINARY(16)")
     private UUID id;
 
-    @Unique String authId;
-    String name;
+    @Unique
+    String authId;
+
+    @Embedded
+    Name name;
+
     Set<Role> roles = Set.of(Role.ROLE_USER);
 
     public Member(String authId, String name) {
         this.authId = authId;
-        this.name = name;
+        this.name = new Name(name);
     }
 
     public String getId() {
         return this.id.toString();
+    }
+
+    public String getName() {
+        return name.getValue();
     }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Name.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Name.java
@@ -2,10 +2,12 @@ package online.partyrun.partyrunauthenticationservice.domain.member.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.InvalidMemberNameException;
 
 import java.util.Objects;

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Name.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Name.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 
 @Getter
 @Embeddable
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Name {
 

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Name.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Name.java
@@ -1,0 +1,41 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunauthenticationservice.domain.member.exception.InvalidMemberNameException;
+
+import java.util.Objects;
+
+@Getter
+@Embeddable
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Name {
+
+    private static final int MAX_LENGTH = 6;
+
+    @Column(name = "name")
+    String value;
+
+    public Name(String value) {
+        validateName(value);
+        this.value = refine(value);
+    }
+
+    private void validateName(String value) {
+        if (Objects.isNull(value) || value.isBlank()) {
+            throw new InvalidMemberNameException();
+        }
+    }
+
+    private String refine(String value) {
+        if (value.length() > MAX_LENGTH) {
+            return value.substring(0, MAX_LENGTH);
+        }
+        return value;
+    }
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/exception/InvalidMemberNameException.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/exception/InvalidMemberNameException.java
@@ -1,0 +1,10 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.exception;
+
+import online.partyrun.partyrunauthenticationservice.global.exception.BadRequestException;
+
+public class InvalidMemberNameException extends BadRequestException {
+
+    public InvalidMemberNameException() {
+        super("Member의 이름은 빈 값일 수 없습니다.");
+    }
+}

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/NameTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/NameTest.java
@@ -1,0 +1,48 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.entity;
+
+import online.partyrun.partyrunauthenticationservice.domain.member.exception.InvalidMemberNameException;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Name")
+class NameTest {
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 이름을_생성할_때 {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("빈 값이면 예외를 던진다.")
+        void returnInvalidException(String value) {
+            assertThatThrownBy(() -> new Name(value))
+                    .isInstanceOf(InvalidMemberNameException.class);
+        }
+
+        @Test
+        @DisplayName("6자 초과이면 6자까지만 저장한다.")
+        void createSixLength() {
+            String value = "박성우박현준노준혁";
+            Name name = new Name(value);
+
+            assertThat(name.getValue()).isEqualTo(value.substring(0, 6));
+        }
+
+        @Test
+        @DisplayName("6자 미만이면 바로 저장한다.")
+        void create() {
+            String value = "박성우박현준";
+            Name name = new Name(value);
+
+            assertThat(name.getValue()).isEqualTo(value);
+        }
+    }
+}

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/NameTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/NameTest.java
@@ -1,16 +1,14 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.entity;
 
-import online.partyrun.partyrunauthenticationservice.domain.member.exception.InvalidMemberNameException;
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.springframework.web.bind.annotation.PathVariable;
-
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+
+import online.partyrun.partyrunauthenticationservice.domain.member.exception.InvalidMemberNameException;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 @DisplayName("Name")
 class NameTest {


### PR DESCRIPTION
### 변경된 점 

이름을 저장할 때, 파티런의 국룰대로 6자 제한을 하였습니다.

### 알아야할 점
Embedded를 사용하였습니다.
Name 이라는 값 객체를 사용하였습니다.
이름에 대한 책임을 Name으로 넘겨주었습니다.
