### PR TITLE
최초로 멤버 저장 시, 기본 profile을 지정한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -19,7 +19,8 @@ import java.util.UUID;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Member {
 
-    private static final String DEFAULT_PROFILE = "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4";
+    private static final String DEFAULT_PROFILE =
+            "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4";
 
     @Id
     @GeneratedValue(generator = "uuid2")
@@ -31,8 +32,7 @@ public class Member {
 
     @Embedded Name name;
 
-    @Embedded
-    Profile profile;
+    @Embedded Profile profile;
 
     Set<Role> roles = Set.of(Role.ROLE_USER);
 

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -19,6 +19,8 @@ import java.util.UUID;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Member {
 
+    private static final String DEFAULT_PROFILE = "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4";
+
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
@@ -29,11 +31,15 @@ public class Member {
 
     @Embedded Name name;
 
+    @Embedded
+    Profile profile;
+
     Set<Role> roles = Set.of(Role.ROLE_USER);
 
     public Member(String authId, String name) {
         this.authId = authId;
         this.name = new Name(name);
+        this.profile = new Profile(DEFAULT_PROFILE);
     }
 
     public String getId() {

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Profile.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Profile.java
@@ -2,10 +2,12 @@ package online.partyrun.partyrunauthenticationservice.domain.member.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.InvalidMemberProfileException;
 
 import java.util.Objects;

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Profile.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Profile.java
@@ -1,0 +1,34 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunauthenticationservice.domain.member.exception.InvalidMemberProfileException;
+
+import java.util.Objects;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Profile {
+
+    private static final String URL_PREFIX = "https://";
+
+    @Column(name = "profile")
+    String value;
+
+    public Profile(String value) {
+        validateProfile(value);
+        this.value = value;
+    }
+
+    private void validateProfile(String value) {
+        if (Objects.isNull(value) || value.isBlank() || !value.startsWith(URL_PREFIX)) {
+            throw new InvalidMemberProfileException(value);
+        }
+    }
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Profile.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Profile.java
@@ -18,8 +18,6 @@ import java.util.Objects;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Profile {
 
-    private static final String URL_PREFIX = "https://";
-
     @Column(name = "profile")
     String value;
 
@@ -29,7 +27,7 @@ public class Profile {
     }
 
     private void validateProfile(String value) {
-        if (Objects.isNull(value) || value.isBlank() || !value.startsWith(URL_PREFIX)) {
+        if (Objects.isNull(value) || value.isBlank()) {
             throw new InvalidMemberProfileException(value);
         }
     }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/exception/InvalidMemberProfileException.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/exception/InvalidMemberProfileException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.exception;
+
+import online.partyrun.partyrunauthenticationservice.global.exception.BadRequestException;
+
+public class InvalidMemberProfileException extends BadRequestException {
+    public InvalidMemberProfileException(String value) {
+        super(String.format("멤버의 프로필은 %s 일 수 없습니다.", value));
+    }
+}

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/ProfileTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/ProfileTest.java
@@ -1,0 +1,34 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.entity;
+
+import online.partyrun.partyrunauthenticationservice.domain.member.exception.InvalidMemberProfileException;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Profile")
+class ProfileTest {
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 프로필을_생성할_때 {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("빈 값이면 예외를 던진다.")
+        void throwInvalidException(String value) {
+            assertThatThrownBy(() -> new Profile(value))
+                    .isInstanceOf(InvalidMemberProfileException.class);
+        }
+
+        @Test
+        @DisplayName("https:// 로 시작하지 않으면 예외를 던진다.")
+        void throwInvalidPrefixException() {
+            String value = "www.naver.com";
+
+            assertThatThrownBy(() -> new Profile(value))
+                    .isInstanceOf(InvalidMemberProfileException.class);
+        }
+    }
+}

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/ProfileTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/ProfileTest.java
@@ -21,14 +21,5 @@ class ProfileTest {
             assertThatThrownBy(() -> new Profile(value))
                     .isInstanceOf(InvalidMemberProfileException.class);
         }
-
-        @Test
-        @DisplayName("https:// 로 시작하지 않으면 예외를 던진다.")
-        void throwInvalidPrefixException() {
-            String value = "www.naver.com";
-
-            assertThatThrownBy(() -> new Profile(value))
-                    .isInstanceOf(InvalidMemberProfileException.class);
-        }
     }
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/ProfileTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/ProfileTest.java
@@ -1,12 +1,12 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.entity;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.InvalidMemberProfileException;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Profile")
 class ProfileTest {


### PR DESCRIPTION
### 변경된 점

최초에 멤버는 프로필 사진이 존재하지 않습니다. 따라서 가입 시 profile을 지정해주는 작업을 진행했습니다.

처음에 FirebaseToken 내부에 존재하는 getPicture() 메소드로 구글 프로필을 가져오려고 했는데, 찾아본 결과 프로필을 지정하지 않았다면 null을  반환할 수도 있다네요.

이건 안드로이드 개발자와 토큰을 통해 프사가 없는 구글 계정을 조회해보아야 정확하게 알 수 있을 것 같습니다.

따라서 기본적으로 저장하는 사진을 다른 것으로 설정했습니다. 
저장하려는 default 사진은 링크를 접속해보면 확인할 수 있습니다.

### 알아야할 점
현재 Member 내부에서 상수로 default url 을 가지고 있습니다.
이를 외부에서 주입하는 방식으로 해야하나? 고민이 되네요. 답변 부탁드립니다.

profile을 검증하는 로직이 아직 좀 구려요,, 
이 부분은 차차 개선해나가는것으로 하겠습니다.
