### PR TITLE
멤버 엔티티의 생성 시간을 기록한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunauthenticationservice/PartyRunAuthenticationServiceApplication.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/PartyRunAuthenticationServiceApplication.java
@@ -2,7 +2,9 @@ package online.partyrun.partyrunauthenticationservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class PartyRunAuthenticationServiceApplication {
     public static void main(String[] args) {

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -1,10 +1,12 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.entity;
 
 import jakarta.persistence.*;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import org.checkerframework.common.aliasing.qual.Unique;
 import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.annotation.CreatedDate;
@@ -33,8 +35,7 @@ public class Member {
 
     Set<Role> roles = Set.of(Role.ROLE_USER);
 
-    @CreatedDate
-    private LocalDateTime createdAt;
+    @CreatedDate private LocalDateTime createdAt;
 
     public Member(String authId, String name) {
         this.authId = authId;

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -1,15 +1,16 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.entity;
 
 import jakarta.persistence.*;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import org.checkerframework.common.aliasing.qual.Unique;
 import org.hibernate.annotations.GenericGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.UUID;
 
@@ -17,6 +18,7 @@ import java.util.UUID;
 @Entity
 @NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
 public class Member {
 
     @Id
@@ -30,6 +32,9 @@ public class Member {
     @Embedded Name name;
 
     Set<Role> roles = Set.of(Role.ROLE_USER);
+
+    @CreatedDate
+    private LocalDateTime createdAt;
 
     public Member(String authId, String name) {
         this.authId = authId;

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -35,7 +35,9 @@ public class Member {
 
     Set<Role> roles = Set.of(Role.ROLE_USER);
 
-    @CreatedDate private LocalDateTime createdAt;
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 
     public Member(String authId, String name) {
         this.authId = authId;

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/auth/controller/AuthControllerTest.java
@@ -1,5 +1,10 @@
 package online.partyrun.partyrunauthenticationservice.domain.auth.controller;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import online.partyrun.jwtmanager.dto.JwtToken;
 import online.partyrun.partyrunauthenticationservice.domain.auth.dto.IdTokenRequest;
 import online.partyrun.partyrunauthenticationservice.domain.auth.exception.IllegalIdTokenException;
@@ -13,11 +18,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("AuthController는")
 @AutoConfigureDataJpa

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/auth/controller/AuthControllerTest.java
@@ -1,10 +1,5 @@
 package online.partyrun.partyrunauthenticationservice.domain.auth.controller;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import online.partyrun.jwtmanager.dto.JwtToken;
 import online.partyrun.partyrunauthenticationservice.domain.auth.dto.IdTokenRequest;
 import online.partyrun.partyrunauthenticationservice.domain.auth.exception.IllegalIdTokenException;
@@ -12,13 +7,20 @@ import online.partyrun.partyrunauthenticationservice.domain.auth.service.AuthSer
 import online.partyrun.testmanager.docs.RestControllerNoneAuthTest;
 
 import org.junit.jupiter.api.*;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @DisplayName("AuthController는")
+@AutoConfigureDataJpa
 class AuthControllerTest extends RestControllerNoneAuthTest {
     @MockBean AuthService authService;
 


### PR DESCRIPTION
### 변경된 점

`@CreatedDate`를 통해 멤버가 언제 생성되었는지 확인할 수 있도록 하였습니다.

지금 당장은 `@CreatedDate` 를 확인할 필요는 없습니다.
하지만 디버깅을 해보거나, 실제 서비스를 운영하게 될 때, 멤버가 언제 생성되는지 확인할 수 있는 것이 큰 도움이 될 것 같아서 추가했습니다.