### PR TITLE
멤버가 생성되면, 이벤트를 발행한다.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,3 @@ jobs:
         run: chmod +x ./gradlew
       - name: Build with Gradle
         run: ./gradlew build
-        env:
-          FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET }}
-
-      

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,12 @@ bootJar {
     dependsOn createDocument
 }
 
+dependencyManagement {
+    imports {
+        mavenBom 'software.amazon.awssdk:bom:2.20.120'
+    }
+}
+
 dependencies {
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -79,6 +85,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.google.firebase:firebase-admin:9.1.1'
     implementation 'com.github.SWM-KAWAI-MANS:jwt-manager:1.3.0'
+    implementation 'software.amazon.awssdk:sns'
 
     //lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -7,8 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
+import online.partyrun.partyrunauthenticationservice.domain.member.event.MemberCreateEvent;
 import org.checkerframework.common.aliasing.qual.Unique;
-import org.hibernate.annotations.GenericGenerator;
+import org.springframework.data.domain.AbstractAggregateRoot;
 
 import java.util.Set;
 import java.util.UUID;
@@ -17,13 +18,10 @@ import java.util.UUID;
 @Entity
 @NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
-public class Member {
+public class Member extends AbstractAggregateRoot<Member> {
 
     @Id
-    @GeneratedValue(generator = "uuid2")
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
-    @Column(columnDefinition = "BINARY(16)")
-    private UUID id;
+    private String id;
 
     @Unique String authId;
 
@@ -32,12 +30,11 @@ public class Member {
     Set<Role> roles = Set.of(Role.ROLE_USER);
 
     public Member(String authId, String name) {
+        this.id = UUID.randomUUID().toString();
         this.authId = authId;
         this.name = new Name(name);
-    }
 
-    public String getId() {
-        return this.id.toString();
+        registerEvent(new MemberCreateEvent(this.id));
     }
 
     public String getName() {

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -9,6 +9,7 @@ import lombok.experimental.FieldDefaults;
 
 import online.partyrun.partyrunauthenticationservice.domain.member.event.Event;
 import online.partyrun.partyrunauthenticationservice.domain.member.event.EventType;
+
 import org.checkerframework.common.aliasing.qual.Unique;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.domain.AbstractAggregateRoot;
@@ -28,8 +29,7 @@ public class Member extends AbstractAggregateRoot<Member> {
     private static final String DEFAULT_PROFILE =
             "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4";
 
-    @Id
-    private String id;
+    @Id private String id;
 
     @Unique String authId;
 

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
-import online.partyrun.partyrunauthenticationservice.domain.member.event.MemberCreateEvent;
+import online.partyrun.partyrunauthenticationservice.domain.member.event.Event;
+import online.partyrun.partyrunauthenticationservice.domain.member.event.EventType;
 import org.checkerframework.common.aliasing.qual.Unique;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.domain.AbstractAggregateRoot;
@@ -47,7 +48,8 @@ public class Member extends AbstractAggregateRoot<Member> {
         this.authId = authId;
         this.name = new Name(name);
         this.profile = new Profile(DEFAULT_PROFILE);
-        registerEvent(new MemberCreateEvent(this.id));
+
+        registerEvent(new Event(EventType.CREATED, this.id));
     }
 
     public String getName() {

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
@@ -1,4 +1,3 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.event;
 
-public record Event(EventType type, Object value) {
-}
+public record Event(EventType type, Object value) {}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
@@ -1,4 +1,4 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.event;
 
-public record MemberCreateEvent(String id) {
+public record Event(EventType type, Object value) {
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/EventType.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/EventType.java
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.event;
+
+public enum EventType {
+    CREATED
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/MemberCreateEvent.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/MemberCreateEvent.java
@@ -1,0 +1,4 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.event;
+
+public record MemberCreateEvent(String id) {
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/MemberEventPublisher.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/MemberEventPublisher.java
@@ -2,10 +2,13 @@ package online.partyrun.partyrunauthenticationservice.domain.member.event;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
 
@@ -17,23 +20,23 @@ public class MemberEventPublisher {
     SnsClient snsClient;
     ObjectMapper objectMapper;
 
-    public MemberEventPublisher(@Value("${aws.sns.arn}") String arn, SnsClient snsClient, ObjectMapper objectMapper) {
+    public MemberEventPublisher(
+            @Value("${aws.sns.arn}") String arn, SnsClient snsClient, ObjectMapper objectMapper) {
         this.arn = arn;
         this.snsClient = snsClient;
         this.objectMapper = objectMapper;
     }
 
-
     public void publish(Event event) {
         try {
-        final PublishRequest request = PublishRequest.builder()
-                    .topicArn(this.arn)
-                    .message(objectMapper.writeValueAsString(event))
-                    .build();
+            final PublishRequest request =
+                    PublishRequest.builder()
+                            .topicArn(this.arn)
+                            .message(objectMapper.writeValueAsString(event))
+                            .build();
             snsClient.publish(request);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(String.format("%s 이벤트를 발행하는데에 실패했습니다.", event));
         }
-
     }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/MemberEventPublisher.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/MemberEventPublisher.java
@@ -1,0 +1,39 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+
+@Component
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class MemberEventPublisher {
+
+    String arn;
+    SnsClient snsClient;
+    ObjectMapper objectMapper;
+
+    public MemberEventPublisher(@Value("${aws.sns.arn}") String arn, SnsClient snsClient, ObjectMapper objectMapper) {
+        this.arn = arn;
+        this.snsClient = snsClient;
+        this.objectMapper = objectMapper;
+    }
+
+
+    public void publish(Event event) {
+        try {
+        final PublishRequest request = PublishRequest.builder()
+                    .topicArn(this.arn)
+                    .message(objectMapper.writeValueAsString(event))
+                    .build();
+            snsClient.publish(request);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(String.format("%s 이벤트를 발행하는데에 실패했습니다.", event));
+        }
+
+    }
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/MemberEventPublisher.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/MemberEventPublisher.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 
 import online.partyrun.partyrunauthenticationservice.global.exception.InternalServerErrorException;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/MemberEventPublisher.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/MemberEventPublisher.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 
+import online.partyrun.partyrunauthenticationservice.global.exception.InternalServerErrorException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -36,7 +37,7 @@ public class MemberEventPublisher {
                             .build();
             snsClient.publish(request);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("%s 이벤트를 발행하는데에 실패했습니다.", event));
+            throw new InternalServerErrorException(String.format("%s 이벤트를 발행하는데에 실패했습니다.", event));
         }
     }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/NotificationService.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/NotificationService.java
@@ -1,0 +1,24 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.service;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunauthenticationservice.domain.member.event.Event;
+import online.partyrun.partyrunauthenticationservice.domain.member.event.MemberEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Async
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class NotificationService {
+
+    MemberEventPublisher publisher;
+
+    @TransactionalEventListener
+    public void notifyMemberCreated(Event event) {
+        publisher.publish(event);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/NotificationService.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/NotificationService.java
@@ -3,8 +3,10 @@ package online.partyrun.partyrunauthenticationservice.domain.member.service;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunauthenticationservice.domain.member.event.Event;
 import online.partyrun.partyrunauthenticationservice.domain.member.event.MemberEventPublisher;
+
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionalEventListener;

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/global/config/AsyncConfig.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/global/config/AsyncConfig.java
@@ -1,0 +1,27 @@
+package online.partyrun.partyrunauthenticationservice.global.config;
+
+import online.partyrun.partyrunauthenticationservice.global.controller.AsyncExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+    private static final int THREAD_COUNT = 2;
+
+    @Override
+    public Executor getAsyncExecutor() {
+        return Executors.newFixedThreadPool(THREAD_COUNT);
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new AsyncExceptionHandler();
+    }
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/global/config/AsyncConfig.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/global/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package online.partyrun.partyrunauthenticationservice.global.config;
 
 import online.partyrun.partyrunauthenticationservice.global.controller.AsyncExceptionHandler;
+
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/global/config/SnsConfig.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/global/config/SnsConfig.java
@@ -1,0 +1,24 @@
+package online.partyrun.partyrunauthenticationservice.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+
+@Configuration
+public class SnsConfig {
+    @Bean
+    public SnsClient snsClient(@Value("${aws.sns.access-key}") String accessKey,
+                               @Value("${aws.sns.secret-key}") String secretKey,
+                               @Value("${aws.sns.region}") String region) {
+
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return SnsClient.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/global/config/SnsConfig.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/global/config/SnsConfig.java
@@ -3,6 +3,7 @@ package online.partyrun.partyrunauthenticationservice.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -11,9 +12,10 @@ import software.amazon.awssdk.services.sns.SnsClient;
 @Configuration
 public class SnsConfig {
     @Bean
-    public SnsClient snsClient(@Value("${aws.sns.access-key}") String accessKey,
-                               @Value("${aws.sns.secret-key}") String secretKey,
-                               @Value("${aws.sns.region}") String region) {
+    public SnsClient snsClient(
+            @Value("${aws.sns.access-key}") String accessKey,
+            @Value("${aws.sns.secret-key}") String secretKey,
+            @Value("${aws.sns.region}") String region) {
 
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
         return SnsClient.builder()

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/global/controller/AsyncExceptionHandler.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/global/controller/AsyncExceptionHandler.java
@@ -1,0 +1,19 @@
+package online.partyrun.partyrunauthenticationservice.global.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+@Slf4j
+public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.warn("비동기 처리중 예외가 발생했습니다\n" +
+                "예외 메세지 : " + ex.getMessage() + "\n" +
+                "메소드 : " + method.getName() + "\n" +
+                "파라미터 : " + Arrays.toString(params));
+    }
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/global/controller/AsyncExceptionHandler.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/global/controller/AsyncExceptionHandler.java
@@ -1,6 +1,7 @@
 package online.partyrun.partyrunauthenticationservice.global.controller;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 
 import java.lang.reflect.Method;
@@ -11,9 +12,15 @@ public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
 
     @Override
     public void handleUncaughtException(Throwable ex, Method method, Object... params) {
-        log.warn("비동기 처리중 예외가 발생했습니다\n" +
-                "예외 메세지 : " + ex.getMessage() + "\n" +
-                "메소드 : " + method.getName() + "\n" +
-                "파라미터 : " + Arrays.toString(params));
+        log.warn(
+                "비동기 처리중 예외가 발생했습니다\n"
+                        + "예외 메세지 : "
+                        + ex.getMessage()
+                        + "\n"
+                        + "메소드 : "
+                        + method.getName()
+                        + "\n"
+                        + "파라미터 : "
+                        + Arrays.toString(params));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,16 @@ spring:
     hibernate:
       ddl-auto: create-drop
 
+firebase:
+  secret: "test firebase secret"
+
+aws:
+  sns:
+    access-key: "test aws sns access key"
+    secret-key: "test aws sns secret key"
+    region: "test aws sns region"
+    arn: "test aws sns arn"
+
 jwt:
   access-secret-key: "asfasdfaasfasdfasdfadfasdfasdfasdfaasfasdfasdfadfasdfasdfasdfaasfasdfasdfadfasdfasdfasdfaasfasdfasdfadfasdfasdfasdfaasfasdfasdfadfasd"
   access-expire-second: 1000000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,13 @@ server:
 firebase:
   secret: ${FIREBASE_SECRET}
 
+aws:
+  sns:
+    access-key: ${AWS_SNS_ACCESS_KEY}
+    secret-key: ${AWS_SNS_SECRET_KEY}
+    region: ${AWS_SNS_REGION}
+    arn: ${AWS_SNS_ARN}
+
 ---
 
 spring:

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/PartyRunAuthenticationServiceApplicationTests.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/PartyRunAuthenticationServiceApplicationTests.java
@@ -2,8 +2,10 @@ package online.partyrun.partyrunauthenticationservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 @SpringBootTest
+@Import(TestConfig.class)
 class PartyRunAuthenticationServiceApplicationTests {
 
     @Test

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
@@ -1,16 +1,17 @@
 package online.partyrun.partyrunauthenticationservice;
 
-import online.partyrun.partyrunauthenticationservice.domain.auth.service.firebase.FirebaseHandler;
 
+import online.partyrun.partyrunauthenticationservice.domain.auth.service.firebase.FirebaseHandler;
+import online.partyrun.partyrunauthenticationservice.domain.member.event.MemberEventPublisher;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-import software.amazon.awssdk.services.sns.SnsClient;
 
 @TestConfiguration
 public class TestConfig {
 
-    @MockBean SnsClient snsClient;
+    @MockBean
+    MemberEventPublisher memberEventPublisher;
 
-    @MockBean FirebaseHandler firebaseHandler;
+    @MockBean
+    FirebaseHandler firebaseHandler;
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
@@ -1,15 +1,21 @@
 package online.partyrun.partyrunauthenticationservice;
 
+
 import online.partyrun.partyrunauthenticationservice.domain.auth.service.firebase.FirebaseHandler;
 import online.partyrun.partyrunauthenticationservice.domain.member.event.MemberEventPublisher;
-
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 @TestConfiguration
 public class TestConfig {
 
-    @MockBean MemberEventPublisher memberEventPublisher;
+    @MockBean
+    SnsClient snsClient;
 
-    @MockBean FirebaseHandler firebaseHandler;
+    @MockBean
+    FirebaseHandler firebaseHandler;
+
+    @MockBean
+    MemberEventPublisher memberEventPublisher;
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
@@ -1,21 +1,19 @@
 package online.partyrun.partyrunauthenticationservice;
 
-
 import online.partyrun.partyrunauthenticationservice.domain.auth.service.firebase.FirebaseHandler;
 import online.partyrun.partyrunauthenticationservice.domain.member.event.MemberEventPublisher;
+
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+
 import software.amazon.awssdk.services.sns.SnsClient;
 
 @TestConfiguration
 public class TestConfig {
 
-    @MockBean
-    SnsClient snsClient;
+    @MockBean SnsClient snsClient;
 
-    @MockBean
-    FirebaseHandler firebaseHandler;
+    @MockBean FirebaseHandler firebaseHandler;
 
-    @MockBean
-    MemberEventPublisher memberEventPublisher;
+    @MockBean MemberEventPublisher memberEventPublisher;
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
@@ -1,17 +1,15 @@
 package online.partyrun.partyrunauthenticationservice;
 
-
 import online.partyrun.partyrunauthenticationservice.domain.auth.service.firebase.FirebaseHandler;
 import online.partyrun.partyrunauthenticationservice.domain.member.event.MemberEventPublisher;
+
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @TestConfiguration
 public class TestConfig {
 
-    @MockBean
-    MemberEventPublisher memberEventPublisher;
+    @MockBean MemberEventPublisher memberEventPublisher;
 
-    @MockBean
-    FirebaseHandler firebaseHandler;
+    @MockBean FirebaseHandler firebaseHandler;
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
@@ -1,0 +1,17 @@
+package online.partyrun.partyrunauthenticationservice;
+
+
+import online.partyrun.partyrunauthenticationservice.domain.auth.service.firebase.FirebaseHandler;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import software.amazon.awssdk.services.sns.SnsClient;
+
+@TestConfiguration
+public class TestConfig {
+
+    @MockBean
+    SnsClient snsClient;
+
+    @MockBean
+    FirebaseHandler firebaseHandler;
+}

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
@@ -1,17 +1,16 @@
 package online.partyrun.partyrunauthenticationservice;
 
-
 import online.partyrun.partyrunauthenticationservice.domain.auth.service.firebase.FirebaseHandler;
+
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+
 import software.amazon.awssdk.services.sns.SnsClient;
 
 @TestConfiguration
 public class TestConfig {
 
-    @MockBean
-    SnsClient snsClient;
+    @MockBean SnsClient snsClient;
 
-    @MockBean
-    FirebaseHandler firebaseHandler;
+    @MockBean FirebaseHandler firebaseHandler;
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/auth/service/FirebaseAuthServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/auth/service/FirebaseAuthServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.jwtmanager.dto.JwtToken;
+import online.partyrun.partyrunauthenticationservice.TestConfig;
 import online.partyrun.partyrunauthenticationservice.domain.auth.exception.IllegalIdTokenException;
 import online.partyrun.partyrunauthenticationservice.domain.auth.exception.NoSuchRefreshTokenException;
 import online.partyrun.partyrunauthenticationservice.domain.auth.service.firebase.FirebaseAuthService;
@@ -21,14 +22,16 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 
 import java.util.Set;
 
 @SpringBootTest
 @DisplayName("FirebaseAuthService")
 @EnableRedisTest
+@Import(TestConfig.class)
 class FirebaseAuthServiceTest {
-    @MockBean FirebaseHandler firebaseHandler;
+    @Autowired FirebaseHandler firebaseHandler;
 
     @Autowired FirebaseAuthService firebaseAuthService;
 

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/auth/service/FirebaseAuthServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/auth/service/FirebaseAuthServiceTest.java
@@ -21,7 +21,6 @@ import online.partyrun.testmanager.redis.EnableRedisTest;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 
 import java.util.Set;

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/repository/MemberRepositoryTest.java
@@ -2,13 +2,16 @@ package online.partyrun.partyrunauthenticationservice.domain.member.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import online.partyrun.partyrunauthenticationservice.TestConfig;
 import online.partyrun.partyrunauthenticationservice.domain.member.entity.Member;
 
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@Import(TestConfig.class)
 @DisplayName("MemberRepository")
 class MemberRepositoryTest {
     @Autowired MemberRepository memberRepository;

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberServiceTest.java
@@ -3,6 +3,7 @@ package online.partyrun.partyrunauthenticationservice.domain.member.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import online.partyrun.partyrunauthenticationservice.TestConfig;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberRequest;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.entity.Member;
@@ -12,10 +13,12 @@ import online.partyrun.partyrunauthenticationservice.domain.member.repository.Me
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 import java.util.Set;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @DisplayName("MemberService")
 class MemberServiceTest {
 


### PR DESCRIPTION
### 변경된 점
멤버가 생성되면, 다른 서비스에게 생성되었다는 정보를 전달해야합니다.

이를 위해 아래와 같이 처리하였습니다.


1. 멤버가 생성되면 도메인 이벤트를 발행합니다. ->[ AbstractAggregateRoot 정리 글 ](https://www.notion.so/seongwoo-memo/DDD-Aggregates-and-DomainEvents-d8efd62185ba4e039b9caac51d41432e?pvs=4)
2. 발행된 이벤트를 NotificationService에서 처리합니다.
3. MemberEventPublisher에서 SNS를 통해 이벤트를 전송합니다.

### 알아야할 점
`@TransactionalEventListener` 를 통해 이벤트를 처리합니다.
이는 기본 설정이 트랜잭션이 끝난 이후에, 이벤트를 처리하도록 설정되어있습니다.
