### PR TITLE
멤버들을 조회한다.

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -23,3 +23,6 @@ operation::refresh token is invalid[snippets='http-request,http-response']
 operation::find member[snippets='http-request,http-response']
 === 잘못된 token으로 멤버 조회
 operation::fail to find member[snippets='http-request,http-response']
+
+=== 멤버들 조회
+operation::find members[snippets='http-request,http-response']

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
@@ -1,14 +1,16 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.controller;
 
+import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
+import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersRequest;
+import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.service.MemberService;
-
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,5 +25,10 @@ public class MemberController {
     @GetMapping("me")
     public MemberResponse findMe(Authentication auth) {
         return memberService.findMember(auth.getName());
+    }
+
+    @GetMapping
+    public MembersResponse findMembers(@Valid @RequestBody MembersRequest request) {
+        return memberService.findMembers(request);
     }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
@@ -1,13 +1,16 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.controller;
 
 import jakarta.validation.Valid;
+
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersRequest;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.service.MemberService;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersRequest.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersRequest.java
@@ -4,5 +4,4 @@ import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
-public record MembersRequest(@NotNull List<String> ids) {
-}
+public record MembersRequest(@NotNull List<String> ids) {}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersRequest.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersRequest.java
@@ -1,0 +1,8 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record MembersRequest(@NotNull List<String> ids) {
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersResponse.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersResponse.java
@@ -1,5 +1,16 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.dto;
 
+import online.partyrun.partyrunauthenticationservice.domain.member.entity.Member;
+
 import java.util.List;
 
-public record MembersResponse(List<MemberResponse> members) {}
+public record MembersResponse(List<MemberResponse> members) {
+
+    public static MembersResponse from(List<Member> members) {
+        return new MembersResponse(
+                members.stream()
+                        .map(MemberResponse::new)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersResponse.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersResponse.java
@@ -1,0 +1,7 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.dto;
+
+import java.util.List;
+
+public record MembersResponse(List<MemberResponse> members) {
+}
+

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersResponse.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersResponse.java
@@ -2,6 +2,4 @@ package online.partyrun.partyrunauthenticationservice.domain.member.dto;
 
 import java.util.List;
 
-public record MembersResponse(List<MemberResponse> members) {
-}
-
+public record MembersResponse(List<MemberResponse> members) {}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersResponse.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MembersResponse.java
@@ -7,10 +7,6 @@ import java.util.List;
 public record MembersResponse(List<MemberResponse> members) {
 
     public static MembersResponse from(List<Member> members) {
-        return new MembersResponse(
-                members.stream()
-                        .map(MemberResponse::new)
-                        .toList()
-        );
+        return new MembersResponse(members.stream().map(MemberResponse::new).toList());
     }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
@@ -42,6 +42,6 @@ public class MemberService {
         final List<String> ids = request.ids();
         final List<Member> members = memberRepository.findAllById(ids);
 
-        return new MembersResponse(members.stream().map(MemberResponse::new).toList());
+        return MembersResponse.from(members);
     }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
@@ -4,15 +4,15 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
-import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberAuthRequest;
-import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberAuthResponse;
-import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
+import online.partyrun.partyrunauthenticationservice.domain.member.dto.*;
 import online.partyrun.partyrunauthenticationservice.domain.member.entity.Member;
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunauthenticationservice.domain.member.repository.MemberRepository;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
@@ -35,5 +35,13 @@ public class MemberService {
                 memberRepository.findById(id).orElseThrow(() -> new MemberNotFoundException(id));
 
         return new MemberResponse(member);
+    }
+
+    public MembersResponse findMembers(MembersRequest request) {
+
+        final List<String> ids = request.ids();
+        final List<Member> members = memberRepository.findAllById(ids);
+
+        return new MembersResponse(members.stream().map(MemberResponse::new).toList());
     }
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import online.partyrun.partyrunauthenticationservice.domain.auth.controller.ControllerTestConfig;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
+import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersRequest;
+import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunauthenticationservice.domain.member.service.MemberService;
 import online.partyrun.testmanager.docs.RestControllerTest;
@@ -20,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 @AutoConfigureDataJpa
 @Import(ControllerTestConfig.class)
@@ -69,6 +72,44 @@ class MemberControllerTest extends RestControllerTest {
             actions.andExpect(status().isNotFound());
 
             setPrintDocs(actions, "fail to find member");
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 멤버_다수를_조회할_때 {
+
+        @Test
+        @DisplayName("정상적인 멤버의 토큰이 주어지면 멤버 정보를 조회한다.")
+        void successFindMember() throws Exception {
+            MembersRequest request = new MembersRequest(List.of("parkseongwoo", "parkhyunjun"));
+
+            MembersResponse response =
+                    new MembersResponse(List.of(new MemberResponse(
+                                    "parkseongwoo",
+                                    "박성우",
+                                    "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4"),
+                            new MemberResponse(
+                                    "parkhyunjun",
+                                    "박현준",
+                                    "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4"))
+                    );
+
+            given(memberService.findMembers(request)).willReturn(response);
+
+            ResultActions actions =
+                    mockMvc.perform(
+                            get("/members")
+                                    .header(
+                                            "Authorization",
+                                            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .characterEncoding(StandardCharsets.UTF_8)
+                                    .content(toRequestBody(request)));
+            actions.andExpect(status().isOk())
+                    .andExpect(content().json(toRequestBody(response)));
+
+            setPrintDocs(actions, "find members");
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
@@ -85,15 +85,16 @@ class MemberControllerTest extends RestControllerTest {
             MembersRequest request = new MembersRequest(List.of("parkseongwoo", "parkhyunjun"));
 
             MembersResponse response =
-                    new MembersResponse(List.of(new MemberResponse(
-                                    "parkseongwoo",
-                                    "박성우",
-                                    "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4"),
-                            new MemberResponse(
-                                    "parkhyunjun",
-                                    "박현준",
-                                    "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4"))
-                    );
+                    new MembersResponse(
+                            List.of(
+                                    new MemberResponse(
+                                            "parkseongwoo",
+                                            "박성우",
+                                            "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4"),
+                                    new MemberResponse(
+                                            "parkhyunjun",
+                                            "박현준",
+                                            "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4")));
 
             given(memberService.findMembers(request)).willReturn(response);
 
@@ -106,8 +107,7 @@ class MemberControllerTest extends RestControllerTest {
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .characterEncoding(StandardCharsets.UTF_8)
                                     .content(toRequestBody(request)));
-            actions.andExpect(status().isOk())
-                    .andExpect(content().json(toRequestBody(response)));
+            actions.andExpect(status().isOk()).andExpect(content().json(toRequestBody(response)));
 
             setPrintDocs(actions, "find members");
         }


### PR DESCRIPTION
### 변경 점
매칭이나 배틀을 실행할 때 멤버들을 조회해야합니다.
이를 위해 멤버 조회 로직을 구현하였습니다.

단순 CRUD 입니다.

멤버 id의 수, 멤버 id의 중복 여부는 체크하지 않았습니다.
하지만 추후에 추가할 예정입니다.