### PR TITLE
멤버 조회 시, 요청 스펙 변경

### DIFF
--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
@@ -3,9 +3,11 @@ package online.partyrun.partyrunauthenticationservice.domain.member.controller;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.service.MemberService;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
@@ -1,21 +1,18 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.controller;
 
-import jakarta.validation.Valid;
-
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
-import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersRequest;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.service.MemberService;
-
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,7 +28,7 @@ public class MemberController {
     }
 
     @GetMapping
-    public MembersResponse findMembers(@Valid @RequestBody MembersRequest request) {
-        return memberService.findMembers(request);
+    public MembersResponse findMembers(@RequestParam List<String> ids) {
+        return memberService.findMembers(ids);
     }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
@@ -37,9 +37,7 @@ public class MemberService {
         return new MemberResponse(member);
     }
 
-    public MembersResponse findMembers(MembersRequest request) {
-
-        final List<String> ids = request.ids();
+    public MembersResponse findMembers(List<String> ids) {
         final List<Member> members = memberRepository.findAllById(ids);
 
         return MembersResponse.from(members);

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
@@ -1,11 +1,18 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.controller;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import online.partyrun.partyrunauthenticationservice.domain.auth.controller.ControllerTestConfig;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunauthenticationservice.domain.member.service.MemberService;
 import online.partyrun.testmanager.docs.RestControllerTest;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -15,12 +22,6 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureDataJpa
 @Import(ControllerTestConfig.class)

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
@@ -1,19 +1,11 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.controller;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import online.partyrun.partyrunauthenticationservice.domain.auth.controller.ControllerTestConfig;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
-import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersRequest;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunauthenticationservice.domain.member.service.MemberService;
 import online.partyrun.testmanager.docs.RestControllerTest;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -23,6 +15,12 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureDataJpa
 @Import(ControllerTestConfig.class)
@@ -82,7 +80,8 @@ class MemberControllerTest extends RestControllerTest {
         @Test
         @DisplayName("정상적인 멤버의 토큰이 주어지면 멤버 정보를 조회한다.")
         void successFindMember() throws Exception {
-            MembersRequest request = new MembersRequest(List.of("parkseongwoo", "parkhyunjun"));
+            String id1 = "parkseongwoo";
+            String id2 = "parkhyunjun";
 
             MembersResponse response =
                     new MembersResponse(
@@ -96,7 +95,7 @@ class MemberControllerTest extends RestControllerTest {
                                             "박현준",
                                             "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4")));
 
-            given(memberService.findMembers(request)).willReturn(response);
+            given(memberService.findMembers(List.of(id1, id2))).willReturn(response);
 
             ResultActions actions =
                     mockMvc.perform(
@@ -106,7 +105,8 @@ class MemberControllerTest extends RestControllerTest {
                                             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .characterEncoding(StandardCharsets.UTF_8)
-                                    .content(toRequestBody(request)));
+                                    .param("ids", id1)
+                                    .param("ids", id2));
             actions.andExpect(status().isOk()).andExpect(content().json(toRequestBody(response)));
 
             setPrintDocs(actions, "find members");


### PR DESCRIPTION
### 변경 점

기존에는 GET 요청에 Body로 id들을 받았습니다.
안드로이드 측에서 Get 요청에 Body를 추가할 수 없다고 요청했기 때문에, 쿼리스트링으로 변경하였습니다.

멤버 조회를 위해 멤버 개별로 조회를 할 수 있지만, API 요청이 많아지기 때문에, 쿼리스트링으로 변경하는 방법을 선택했습니다.