### PR TITLE
멤버 탈퇴를 구현한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     testImplementation 'com.github.SWM-KAWAI-MANS:test-manager:1.0.2'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
+    testImplementation 'org.springframework.security:spring-security-test'
 
     //lombok-test
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
@@ -32,7 +32,7 @@ public class MemberController {
         return memberService.findMembers(ids);
     }
 
-    @DeleteMapping
+    @DeleteMapping("me")
     public MessageResponse deleteMember(Authentication auth) {
         return memberService.deleteMember(auth.getName());
     }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberController.java
@@ -6,13 +6,11 @@ import lombok.experimental.FieldDefaults;
 
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersResponse;
+import online.partyrun.partyrunauthenticationservice.domain.member.dto.MessageResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.service.MemberService;
 
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -32,5 +30,10 @@ public class MemberController {
     @GetMapping
     public MembersResponse findMembers(@RequestParam List<String> ids) {
         return memberService.findMembers(ids);
+    }
+
+    @DeleteMapping
+    public MessageResponse deleteMember(Authentication auth) {
+        return memberService.deleteMember(auth.getName());
     }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MessageResponse.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/dto/MessageResponse.java
@@ -1,0 +1,10 @@
+package online.partyrun.partyrunauthenticationservice.domain.member.dto;
+
+public record MessageResponse(String message) {
+
+    private static final String DEFAULT_MESSAGE = "요청이 정상적으로 처리되었습니다.";
+
+    public MessageResponse() {
+        this(DEFAULT_MESSAGE);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
@@ -42,4 +42,10 @@ public class MemberService {
 
         return MembersResponse.from(members);
     }
+
+    public MessageResponse deleteMember(String id) {
+        memberRepository.deleteById(id);
+
+        return new MessageResponse();
+    }
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
@@ -129,7 +129,7 @@ class MemberControllerTest extends RestControllerTest {
 
             ResultActions actions =
                     mockMvc.perform(
-                            delete("/members")
+                            delete("/members/me")
                                     .with(csrf())
                                     .header(
                                             "Authorization",

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
@@ -1,18 +1,12 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.controller;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import online.partyrun.partyrunauthenticationservice.domain.auth.controller.ControllerTestConfig;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersResponse;
+import online.partyrun.partyrunauthenticationservice.domain.member.dto.MessageResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunauthenticationservice.domain.member.service.MemberService;
 import online.partyrun.testmanager.docs.RestControllerTest;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -22,6 +16,13 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureDataJpa
 @Import(ControllerTestConfig.class)
@@ -42,7 +43,7 @@ class MemberControllerTest extends RestControllerTest {
                             "parkseongwoo",
                             "박성우",
                             "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4");
-            given(memberService.findMember(anyString())).willReturn(response);
+            given(memberService.findMember("defaultUser")).willReturn(response);
 
             ResultActions actions =
                     mockMvc.perform(
@@ -60,7 +61,7 @@ class MemberControllerTest extends RestControllerTest {
         @Test
         @DisplayName("비정상적인 멤버의 토큰이 주어지면 Not Found를 반환한다.")
         void FailToFindMember() throws Exception {
-            given(memberService.findMember(anyString())).willThrow(MemberNotFoundException.class);
+            given(memberService.findMember("defaultUser")).willThrow(MemberNotFoundException.class);
 
             ResultActions actions =
                     mockMvc.perform(
@@ -109,6 +110,33 @@ class MemberControllerTest extends RestControllerTest {
                                     .param("ids", id1)
                                     .param("ids", id2));
             actions.andExpect(status().isOk()).andExpect(content().json(toRequestBody(response)));
+
+            setPrintDocs(actions, "find members");
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 멤버를_삭제할_때 {
+
+        @Test
+        @DisplayName("정상적으로 처리되었다는 메시지를 응답한다.")
+        void successDeleteMember() throws Exception {
+            final MessageResponse response = new MessageResponse();
+
+            given(memberService.deleteMember("defaultUser")).willReturn(response);
+
+            ResultActions actions =
+                    mockMvc.perform(
+                            delete("/members")
+                                    .with(csrf())
+                                    .header(
+                                            "Authorization",
+                                            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .characterEncoding(StandardCharsets.UTF_8));
+            actions.andExpect(status().isOk())
+                    .andExpect(content().json(toRequestBody(response)));
 
             setPrintDocs(actions, "find members");
         }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/controller/MemberControllerTest.java
@@ -1,5 +1,12 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.controller;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import online.partyrun.partyrunauthenticationservice.domain.auth.controller.ControllerTestConfig;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MembersResponse;
@@ -7,6 +14,7 @@ import online.partyrun.partyrunauthenticationservice.domain.member.dto.MessageRe
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunauthenticationservice.domain.member.service.MemberService;
 import online.partyrun.testmanager.docs.RestControllerTest;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -16,13 +24,6 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureDataJpa
 @Import(ControllerTestConfig.class)
@@ -135,8 +136,7 @@ class MemberControllerTest extends RestControllerTest {
                                             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .characterEncoding(StandardCharsets.UTF_8));
-            actions.andExpect(status().isOk())
-                    .andExpect(content().json(toRequestBody(response)));
+            actions.andExpect(status().isOk()).andExpect(content().json(toRequestBody(response)));
 
             setPrintDocs(actions, "find members");
         }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberServiceTest.java
@@ -1,13 +1,17 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import jakarta.persistence.EntityManager;
 import online.partyrun.partyrunauthenticationservice.TestConfig;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberAuthRequest;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberAuthResponse;
+import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.entity.Member;
 import online.partyrun.partyrunauthenticationservice.domain.member.entity.Role;
+import online.partyrun.partyrunauthenticationservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunauthenticationservice.domain.member.repository.MemberRepository;
 
 import org.junit.jupiter.api.*;
@@ -64,6 +68,23 @@ class MemberServiceTest {
                     () -> assertThat(response.authId()).isEqualTo(memberAuthRequest.authId()),
                     () -> assertThat(response.name()).isEqualTo(memberAuthRequest.name()),
                     () -> assertThat(response.roles()).isEqualTo(Set.of(Role.ROLE_USER)));
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 멤버를_삭제할_때 {
+
+        @Test
+        @DisplayName("DB에서 제거한다.")
+        void deleteMember() {
+            final Member savedMember = memberRepository.save(new Member("authId", "박성우"));
+
+            assertThat(memberService.findMember(savedMember.getId())).isNotNull();
+
+            memberService.deleteMember(savedMember.getId());
+            assertThatThrownBy(() -> memberService.findMember(savedMember.getId()))
+                    .isInstanceOf(MemberNotFoundException.class);
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberServiceTest.java
@@ -4,11 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import jakarta.persistence.EntityManager;
 import online.partyrun.partyrunauthenticationservice.TestConfig;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberAuthRequest;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberAuthResponse;
-import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.entity.Member;
 import online.partyrun.partyrunauthenticationservice.domain.member.entity.Role;
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.MemberNotFoundException;


### PR DESCRIPTION
### 변경된 점
멤버 탈퇴 로직을 구현했습니다.
서비스 로직 그냥 id 받으면 delete 해버리는 로직입니다.

1. id를 통해 member를 조회한 뒤 존재하면 삭제, 존재하지 않으면 예외를 터뜨림
2. 그냥 현재처럼 member가 있던 없던 삭제

1, 2 번 중에 선택해서 답글 달아주세요.

찾아보니 법률상의 문제로 soft delete가 문제가 될 수도 있어서 hard delete로 구현했습니다!

마지막에 응답 (MessageResponse)로 주고 있는데, 사실 주고싶지않아요.
근데 클라이언트가 꼭 필요하다니까 주는겁니다.

