### PR TITLE
멤버 삭제를 soft delete로 변경

### DIFF
--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -11,6 +11,8 @@ import online.partyrun.partyrunauthenticationservice.domain.member.event.Event;
 import online.partyrun.partyrunauthenticationservice.domain.member.event.EventType;
 
 import org.checkerframework.common.aliasing.qual.Unique;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.domain.AbstractAggregateRoot;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -23,6 +25,8 @@ import java.util.UUID;
 @Entity
 @NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 @EntityListeners(AuditingEntityListener.class)
 public class Member extends AbstractAggregateRoot<Member> {
 
@@ -38,6 +42,8 @@ public class Member extends AbstractAggregateRoot<Member> {
     @Embedded Profile profile;
 
     Set<Role> roles = Set.of(Role.ROLE_USER);
+
+    boolean isDeleted;
 
     @CreatedDate
     @Column(updatable = false)

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/entity/Member.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
 import online.partyrun.partyrunauthenticationservice.domain.member.event.Event;
-import online.partyrun.partyrunauthenticationservice.domain.member.event.EventType;
 
 import org.checkerframework.common.aliasing.qual.Unique;
 import org.hibernate.annotations.SQLDelete;
@@ -55,7 +54,7 @@ public class Member extends AbstractAggregateRoot<Member> {
         this.name = new Name(name);
         this.profile = new Profile(DEFAULT_PROFILE);
 
-        registerEvent(new Event(EventType.CREATED, this.id));
+        registerEvent(Event.create(this.id));
     }
 
     public String getName() {

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
@@ -6,6 +6,10 @@ public record Event(EventType type, Object value) {
         return new Event(EventType.CREATED, value);
     }
 
+    public static Event delete(Object value) {
+        return new Event(EventType.DELETED, value);
+    }
+
     public boolean isCreated() {
         return this.type.isCreated();
     }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
@@ -9,8 +9,4 @@ public record Event(EventType type, Object value) {
     public static Event delete(Object value) {
         return new Event(EventType.DELETED, value);
     }
-
-    public boolean isCreated() {
-        return this.type.isCreated();
-    }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
@@ -1,3 +1,8 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.event;
 
-public record Event(EventType type, Object value) {}
+public record Event(EventType type, Object value) {
+
+    public static Event create(Object value) {
+        return new Event(EventType.CREATED, value);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/Event.java
@@ -5,4 +5,8 @@ public record Event(EventType type, Object value) {
     public static Event create(Object value) {
         return new Event(EventType.CREATED, value);
     }
+
+    public boolean isCreated() {
+        return this.type.isCreated();
+    }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/EventType.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/EventType.java
@@ -1,5 +1,9 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.event;
 
 public enum EventType {
-    CREATED
+    CREATED;
+
+    public boolean isCreated() {
+        return this == CREATED;
+    }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/EventType.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/EventType.java
@@ -1,7 +1,7 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.event;
 
 public enum EventType {
-    CREATED;
+    CREATED, DELETED;
 
     public boolean isCreated() {
         return this == CREATED;

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/EventType.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/EventType.java
@@ -1,5 +1,6 @@
 package online.partyrun.partyrunauthenticationservice.domain.member.event;
 
 public enum EventType {
-    CREATED, DELETED;
+    CREATED,
+    DELETED;
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/EventType.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/event/EventType.java
@@ -2,8 +2,4 @@ package online.partyrun.partyrunauthenticationservice.domain.member.event;
 
 public enum EventType {
     CREATED, DELETED;
-
-    public boolean isCreated() {
-        return this == CREATED;
-    }
 }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
@@ -46,6 +46,7 @@ public class MemberService {
         return MembersResponse.from(members);
     }
 
+    @Transactional
     public MessageResponse deleteMember(String id) {
         memberRepository.deleteById(id);
         eventPublisher.publishEvent(Event.delete(id));

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
@@ -6,9 +6,11 @@ import lombok.experimental.FieldDefaults;
 
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.*;
 import online.partyrun.partyrunauthenticationservice.domain.member.entity.Member;
+import online.partyrun.partyrunauthenticationservice.domain.member.event.Event;
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunauthenticationservice.domain.member.repository.MemberRepository;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +21,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MemberService {
     MemberRepository memberRepository;
+    ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public MemberAuthResponse getMember(MemberAuthRequest request) {
@@ -45,6 +48,7 @@ public class MemberService {
 
     public MessageResponse deleteMember(String id) {
         memberRepository.deleteById(id);
+        eventPublisher.publishEvent(Event.delete(id));
 
         return new MessageResponse();
     }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberService.java
@@ -34,10 +34,13 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public MemberResponse findMember(String id) {
-        final Member member =
-                memberRepository.findById(id).orElseThrow(() -> new MemberNotFoundException(id));
+        final Member member = getMember(id);
 
         return new MemberResponse(member);
+    }
+
+    private Member getMember(String id) {
+        return memberRepository.findById(id).orElseThrow(() -> new MemberNotFoundException(id));
     }
 
     public MembersResponse findMembers(List<String> ids) {
@@ -48,7 +51,9 @@ public class MemberService {
 
     @Transactional
     public MessageResponse deleteMember(String id) {
-        memberRepository.deleteById(id);
+        final Member member = getMember(id);
+        memberRepository.delete(member);
+
         eventPublisher.publishEvent(Event.delete(id));
 
         return new MessageResponse();

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/NotificationService.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/NotificationService.java
@@ -19,7 +19,7 @@ public class NotificationService {
 
     MemberEventPublisher publisher;
 
-    @TransactionalEventListener
+    @TransactionalEventListener(condition = "#event.isCreated()")
     public void notifyMemberCreated(Event event) {
         publisher.publish(event);
     }

--- a/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/NotificationService.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/domain/member/service/NotificationService.java
@@ -19,8 +19,8 @@ public class NotificationService {
 
     MemberEventPublisher publisher;
 
-    @TransactionalEventListener(condition = "#event.isCreated()")
-    public void notifyMemberCreated(Event event) {
+    @TransactionalEventListener
+    public void notifyMemberEvent(Event event) {
         publisher.publish(event);
     }
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
@@ -6,10 +6,10 @@ import online.partyrun.partyrunauthenticationservice.domain.member.event.MemberE
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.support.GenericApplicationContext;
+
 import software.amazon.awssdk.services.sns.SnsClient;
 
 @TestConfiguration

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/TestConfig.java
@@ -3,9 +3,13 @@ package online.partyrun.partyrunauthenticationservice;
 import online.partyrun.partyrunauthenticationservice.domain.auth.service.firebase.FirebaseHandler;
 import online.partyrun.partyrunauthenticationservice.domain.member.event.MemberEventPublisher;
 
+import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.support.GenericApplicationContext;
 import software.amazon.awssdk.services.sns.SnsClient;
 
 @TestConfiguration
@@ -16,4 +20,11 @@ public class TestConfig {
     @MockBean FirebaseHandler firebaseHandler;
 
     @MockBean MemberEventPublisher memberEventPublisher;
+
+    @Bean
+    @Primary
+    public GenericApplicationContext genericApplicationContext(
+            final GenericApplicationContext gac) {
+        return Mockito.spy(gac);
+    }
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberServiceTest.java
@@ -3,18 +3,22 @@ package online.partyrun.partyrunauthenticationservice.domain.member.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 import online.partyrun.partyrunauthenticationservice.TestConfig;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberAuthRequest;
 import online.partyrun.partyrunauthenticationservice.domain.member.dto.MemberAuthResponse;
 import online.partyrun.partyrunauthenticationservice.domain.member.entity.Member;
 import online.partyrun.partyrunauthenticationservice.domain.member.entity.Role;
+import online.partyrun.partyrunauthenticationservice.domain.member.event.Event;
 import online.partyrun.partyrunauthenticationservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunauthenticationservice.domain.member.repository.MemberRepository;
 
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
 
 import java.util.Set;
@@ -24,8 +28,12 @@ import java.util.Set;
 @DisplayName("MemberService")
 class MemberServiceTest {
 
-    @Autowired MemberService memberService;
-    @Autowired MemberRepository memberRepository;
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    ApplicationEventPublisher eventPublisher;
 
     String authId = "authId";
     String name = "박현준";
@@ -81,8 +89,13 @@ class MemberServiceTest {
             assertThat(memberService.findMember(savedMember.getId())).isNotNull();
 
             memberService.deleteMember(savedMember.getId());
-            assertThatThrownBy(() -> memberService.findMember(savedMember.getId()))
-                    .isInstanceOf(MemberNotFoundException.class);
+            Assertions.assertAll(
+                    () -> then(eventPublisher)
+                            .should(times(1))
+                            .publishEvent(Event.delete(savedMember.getId())),
+                    () -> assertThatThrownBy(() -> memberService.findMember(savedMember.getId()))
+                            .isInstanceOf(MemberNotFoundException.class)
+            );
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunauthenticationservice/domain/member/service/MemberServiceTest.java
@@ -29,14 +29,10 @@ import java.util.Set;
 @DisplayName("MemberService")
 class MemberServiceTest {
 
-    @Autowired
-    MemberService memberService;
-    @Autowired
-    MemberRepository memberRepository;
-    @Autowired
-    ApplicationEventPublisher eventPublisher;
-    @Autowired
-    MemberEventPublisher memberEventPublisher;
+    @Autowired MemberService memberService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired ApplicationEventPublisher eventPublisher;
+    @Autowired MemberEventPublisher memberEventPublisher;
 
     String authId = "authId";
     String name = "박현준";
@@ -57,9 +53,10 @@ class MemberServiceTest {
         void getMember() {
             MemberAuthResponse response = memberService.getMember(memberAuthRequest);
             assertAll(
-                    () -> then(eventPublisher)
-                            .should(times(0))
-                            .publishEvent(Event.create(response.id())),
+                    () ->
+                            then(eventPublisher)
+                                    .should(times(0))
+                                    .publishEvent(Event.create(response.id())),
                     () -> assertThat(response.id()).isNotNull(),
                     () -> assertThat(response.authId()).isEqualTo(member.getAuthId()),
                     () -> assertThat(response.name()).isEqualTo(member.getName()),
@@ -76,9 +73,10 @@ class MemberServiceTest {
         void getMember() {
             MemberAuthResponse response = memberService.getMember(memberAuthRequest);
             assertAll(
-                    () -> then(memberEventPublisher)
-                            .should(times(1))
-                            .publish(Event.create(response.id())),
+                    () ->
+                            then(memberEventPublisher)
+                                    .should(times(1))
+                                    .publish(Event.create(response.id())),
                     () -> assertThat(response.id()).isNotNull(),
                     () -> assertThat(response.authId()).isEqualTo(memberAuthRequest.authId()),
                     () -> assertThat(response.name()).isEqualTo(memberAuthRequest.name()),
@@ -99,15 +97,17 @@ class MemberServiceTest {
 
             memberService.deleteMember(savedMember.getId());
             Assertions.assertAll(
-                    () -> then(eventPublisher)
-                            .should(times(1))
-                            .publishEvent(Event.delete(savedMember.getId())),
-                    () -> then(memberEventPublisher)
-                            .should(times(1))
-                            .publish(Event.delete(savedMember.getId())),
-                    () -> assertThatThrownBy(() -> memberService.findMember(savedMember.getId()))
-                            .isInstanceOf(MemberNotFoundException.class)
-            );
+                    () ->
+                            then(eventPublisher)
+                                    .should(times(1))
+                                    .publishEvent(Event.delete(savedMember.getId())),
+                    () ->
+                            then(memberEventPublisher)
+                                    .should(times(1))
+                                    .publish(Event.delete(savedMember.getId())),
+                    () ->
+                            assertThatThrownBy(() -> memberService.findMember(savedMember.getId()))
+                                    .isInstanceOf(MemberNotFoundException.class));
         }
     }
 }


### PR DESCRIPTION
### 변경된 점

```java
@SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
@Where(clause = "is_deleted = false")
```
두가지 어노테이션을 통해서 간단하게 soft delete를 구현해보았습니다!

멤버를 삭제하고 hard delete를 하게 되면, 추후에 고객이 정보를 요청하면 db에 존재하지 않아서 응답하지 못하게 됩니다. 
따라서 soft delete를 실행하고 일정 기간이 지나면 db에서 지우도록 변경해야합니다.

--- 

추가적으로 member를 조회하고, 없다면 NotFoundException을 터뜨렸습니다.
기존에는 멤버가 없다면 그냥 아무일없이, 메소드가 진행이 되는데
없는 id로 요청하는 것은 명백한 클라이언트 잘못이므로 예외를 터뜨렸습니다.