### PR TITLE
환경 별 Redis 연결 방법 변경

### DIFF
--- a/src/main/java/online/partyrun/partyrunauthenticationservice/global/config/RedisConfig.java
+++ b/src/main/java/online/partyrun/partyrunauthenticationservice/global/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package online.partyrun.partyrunauthenticationservice.global.config;
+
+import io.lettuce.core.RedisURI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import java.util.List;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    @Profile("prd")
+    public LettuceConnectionFactory redisConnectionFactory(@Value("${spring.data.redis.cluster.nodes}") List<String> nodes) {
+        RedisClusterConfiguration config = new RedisClusterConfiguration(nodes);
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    @Profile("!prd")
+    public LettuceConnectionFactory standaloneConnectionFactory(@Value("${spring.data.redis.url}") String redisUrl) {
+        RedisURI redisURI = RedisURI.create(redisUrl);
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisURI.getHost(), redisURI.getPort()));
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,8 +1,7 @@
 spring:
   data:
     redis:
-      host: localhost
-      port: 16379
+      url: redis://localhost:16379
 
   datasource:
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1


### PR DESCRIPTION
### 변경된 점
Spring profile 별로 분리가 되지 않아서 Redis 연결에 실패했습니다.
배틀처럼 환경별로 Redis 연결 방법을 변경했습니다.