### PR TITLE
fix : redis properties 변경

### DIFF
--- a/src/main/resources/application-prd.yml
+++ b/src/main/resources/application-prd.yml
@@ -16,8 +16,7 @@ spring:
 
   data:
     redis:
-      cluster:
-        nodes: ${REDIS_CLUSTER_NODES}
+      url: ${REDIS_URL}
 
   cloud:
     aws:


### PR DESCRIPTION
기존에 redis 관련 properties 입력 시 cluster를 직접 입력했었는데 별도 샘플에서 동일한 환경에서 적용해본 결과 NumberFormatException이 발생하였습니다. 추측하기로는 해당 부분에 node ip를 복수개로 넣는 것 같습니다.

따라서 기존과 같이 URL로 입력하는 방식으로 다시 변경하고자 합니다.